### PR TITLE
Validator factory

### DIFF
--- a/config/common/validator.php
+++ b/config/common/validator.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Psr\Container\ContainerInterface;
+use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -15,6 +16,7 @@ return [
             ->enableAnnotationMapping()
             ->setTranslator($translator)
             ->setTranslationDomain('validators')
+            ->setConstraintValidatorFactory(new ContainerConstraintValidatorFactory($container))
             ->getValidator();
     },
 ];

--- a/src/Validator/PhoneNumAvailableValidator.php
+++ b/src/Validator/PhoneNumAvailableValidator.php
@@ -21,7 +21,7 @@ class PhoneNumAvailableValidator extends ConstraintValidator
 
 // private DriverRepository $driverRepo
 public function __construct(
-    // private DriverRepository $driverRepo
+    private DriverRepository $driverRepo
     )
 {
 }


### PR DESCRIPTION
> Кастомный валидатор работает, пока в его констуктор не передать зависимость от PHP-DI! При этом, говорит что зависимости не подтягиваются:
> ```
> Too few arguments to function PhoneNumAvailableValidator::__construct(),
> 0 passed in vendor/symfony/validator/ConstraintValidatorFactory.php on line 43
> ```

По названию класса в тексте ошибки догадываемся, что `Validator` для создания объектов валидаторов `ConstraintValidator` использует фабрику `ConstraintValidatorFactory`.

Если переходим в фабрику, то там на 43 строке видим простое создание через `new $className()`:

```php
class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
{
    protected $validators = [];

    public function getInstance(Constraint $constraint): ConstraintValidatorInterface
    {
        $className = $constraint->validatedBy();

        if (!isset($this->validators[$className])) {
            $this->validators[$className] = 'validator.expression' === $className
                ? new ExpressionValidator()
                : new $className();
        }

        return $this->validators[$className];
    }
}
```

что и приводит к ошибке отсутствия передачи зависимостей.

Значит нам нужно эту фабрику подменить на другую, которая вместо `new $className()` будет вызывать `$this->container->get($className)` из переданного нами в неё контейнера.

Посмотрим, есть ли там что-то готовое? Если перейдём в интерфейс `ConstraintValidatorFactoryInterface` и посмотрим его реализации, то там увидим два класса:

```php
class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface {}
class ContainerConstraintValidatorFactory implements ConstraintValidatorFactoryInterface {}
```

Если перейдём во второй с `Container` в названии, то там:

```php
class ContainerConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
{
    private ContainerInterface $container;
    private array $validators;

    public function __construct(ContainerInterface $container)
    {
        $this->container = $container;
        $this->validators = [];
    }

    public function getInstance(Constraint $constraint): ConstraintValidatorInterface
    {
        $name = $constraint->validatedBy();

        if (!isset($this->validators[$name])) {
            if ($this->container->has($name)) {
                $this->validators[$name] = $this->container->get($name);
            } else {
                // ...
                $this->validators[$name] = new $name();
            }
        }

        return $this->validators[$name];
    }
}
```

Как раз это нам и нужно.

Значит нам нужно валидатору указать эту фабрику `new ContainerConstraintValidatorFactory($container)`.

Валидатор мы создаём в конфиге через построитель. И там как раз находим метод `setConstraintValidatorFactory`:

```php
return [
    ValidatorInterface::class => static function (ContainerInterface $container): ValidatorInterface {
        return Validation::createValidatorBuilder()
            ->enableAnnotationMapping()
            ->setTranslator($container->get(TranslatorInterface::class))
            ->setTranslationDomain('validators')
            ->setConstraintValidatorFactory(new ContainerConstraintValidatorFactory($container))
            ->getValidator();
    },
];
```

Теперь валидаторы будут доставаться этой фабрикой из контейнера и все зависимости заработают.
